### PR TITLE
Issue #5 - Update to GNOME 44

### DIFF
--- a/org.gnome.GTG.json
+++ b/org.gnome.GTG.json
@@ -1,7 +1,7 @@
 {
   "app-id": "org.gnome.GTG",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "43",
+  "runtime-version": "44",
   "sdk": "org.gnome.Sdk",
   "command": "gtg",
   "finish-args": [

--- a/org.gnome.GTG.json
+++ b/org.gnome.GTG.json
@@ -1,7 +1,7 @@
 {
   "app-id": "org.gnome.GTG",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "41",
+  "runtime-version": "43",
   "sdk": "org.gnome.Sdk",
   "command": "gtg",
   "finish-args": [
@@ -105,12 +105,12 @@
             "sha256": "5b40dc2b39950e78989d515ce6a2c1131f20cc2c413ba28f8d5b582546b40a4c"
         }
       ]
-    },   
+    },
    {
       "name": "liblarch",
       "buildsystem": "simple",
       "build-commands": [
-        "python3 setup.py install --prefix /app"
+        "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} . --no-build-isolation"
       ],
       "sources": [{
         "type": "git",

--- a/org.gnome.GTG.json
+++ b/org.gnome.GTG.json
@@ -127,6 +127,10 @@
         "url": "https://github.com/getting-things-gnome/gtg",
         "tag": "v0.6",
         "commit": "f178348b5393ea1420f1c8399f8082859d01fcae"
+      },
+      {
+        "type": "patch",
+        "path": "patches/gtg-icon-fix.patch"
       }
       ]
     }

--- a/patches/gtg-icon-fix.patch
+++ b/patches/gtg-icon-fix.patch
@@ -1,0 +1,22 @@
+From ba9db8e68d2bd64ed0d4167be898726ac61436db Mon Sep 17 00:00:00 2001
+From: Samyak Jain <samtan106@gmail.com>
+Date: Sun, 26 Jun 2022 21:30:47 +0530
+Subject: [PATCH] update icon
+
+---
+ GTG/backends/backend_caldav.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/GTG/backends/backend_caldav.py b/GTG/backends/backend_caldav.py
+index b199eeb83..ed97c24bd 100644
+--- a/GTG/backends/backend_caldav.py
++++ b/GTG/backends/backend_caldav.py
+@@ -58,7 +58,7 @@ class Backend(PeriodicImportBackend):
+ 
+     _general_description = {
+         GenericBackend.BACKEND_NAME: 'backend_caldav',
+-        GenericBackend.BACKEND_ICON: 'applications-internet',
++        GenericBackend.BACKEND_ICON: 'network-server',
+         GenericBackend.BACKEND_HUMAN_NAME: _('CalDAV tasks'),
+         GenericBackend.BACKEND_AUTHORS: ['Mildred Ki\'Lya',
+                                          'François Schmidts'],


### PR DESCRIPTION
Update to GNOME 43

I don't see any obvious problem here. 

GNOME 41 is EOL.

Close #6 